### PR TITLE
Bug.unauthorized snowflake operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ let main = async () => {
 
 	let alationPermissions = await alation.getUsers(process.env.ALATION_DOMAIN, process.env.ALATION_API_ACCESS_TOKEN, process.env.ALATION_EMAIL);
 	let altrPermissions = await altr.getAdministrators(process.env.ALTR_DOMAIN, ALTR_AUTH);
+	let snowflakePermissions = await snowflake.checkConnection(process.env.SF_ACCOUNT, process.env.SF_DB_USERNAME, process.env.SF_DB_PASSWORD, process.env.SF_ROLE);
 
-	if (alationPermissions && altrPermissions) {
+	if (alationPermissions && altrPermissions && snowflakePermissions) {
 		console.log('Permissions Passed');
 		try {
 			// Gets custom field in Alation named, 'Policy Tags' 
@@ -39,6 +40,7 @@ let main = async () => {
 
 			// Gets all columns in Alation that have 'Policy Tags' set
 			let alationColumns = await alation.getColumns(process.env.ALATION_DOMAIN, process.env.ALATION_API_ACCESS_TOKEN, alationCustomFieldId);
+			alationColumns = utils.filterAlationColumns(alationColumns, alationDbs, process.env.SF_HOSTNAME);
 			if (alationColumns.length == 0) throw new Error('\n No columns were found that contain "Policy Tags" values.');
 			console.log('\nALATION COLUMNS: ' + alationColumns.length);
 

--- a/sfOperations.js
+++ b/sfOperations.js
@@ -140,4 +140,36 @@ let applyPolicyTags = async (account, username, password, role, alationColumns, 
 };
 exports.applyPolicyTags = applyPolicyTags;
 
+/**
+ * Checks if environment variables listed in .env file can make a connection to specified Snowflake host
+ * @param {String} account 
+ * @param {String} username 
+ * @param {String} password 
+ * @param {String} role 
+ * @returns true | false
+ */
+let checkConnection = async (account, username, password, role) => {
+	let connection = snowflake.createConnection({
+		account: account,
+		username: username,
+		password: password,
+		role: role
+	});
+
+	return new Promise((resolve, reject) => {
+		connection.connect(
+			function (err, conn) {
+				if (err) {
+					console.log('Unable to connect to Snowflake.');
+					resolve(false);
+				}
+				else {
+					resolve(true);
+				}
+			}
+		);
+	});
+
+};
+exports.checkConnection = checkConnection;
 

--- a/utils.js
+++ b/utils.js
@@ -10,6 +10,21 @@ let filterAlationDbs = (alationDbs, dbType) => {
 exports.filterAlationDbs = filterAlationDbs;
 
 /**
+ * Filters our Alation columns that are part of a database in a snowflake host that is specified in the environment variables
+ * @param {Array} alationColumns 
+ * @param {Array}} alationDbs 
+ * @param {String} hostname 
+ * @returns 
+ */
+let filterAlationColumns = (alationColumns, alationDbs, hostname) => {
+	return alationColumns.filter(column => {
+		let database = alationDbs.find(database => column.ds_id == database.id);
+		return database.host.toUpperCase() == hostname.toUpperCase();
+	});
+}
+exports.filterAlationColumns = filterAlationColumns;
+
+/**
  * Sorts which databases are already in ALTR and which need to be added to ALTR
  * @param {Array} alationColumns Columns in Alation
  * @param {Array} altrDbs ALTR databases


### PR DESCRIPTION
Bug: Script grabs all columns in Alation that have policy tags, regardless of the Snowflake host the database is in. When environment variables only point to a single snowflake host the script would try to operate on columns outside of that host causing useless and failing snowflake operations.

Fix: Filter out columns based on database host against specified host in environment variables.